### PR TITLE
Fix build errors by using local font and client layout

### DIFF
--- a/app/dashboard/salud/layout.tsx
+++ b/app/dashboard/salud/layout.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import type { ReactNode } from "react"
 import SaludSidebar from "@/components/salud/salud-sidebar"
 import { MobileSidebar } from "@/components/layout/mobile-sidebar"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,11 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter } from "next/font/google"
+import { GeistSans } from "geist/font/sans"
 import "./globals.css"
 import { AuthProvider } from "@/contexts/auth-context"
 import { ThemeProvider } from "@/components/theme-provider"
 import { Toaster } from "@/components/ui/toaster"
 
-const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
   title: "KalabasBoom - Plataforma de Aprendizaje",
@@ -21,7 +20,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body className={inter.className}>
+      <body className={GeistSans.className}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <AuthProvider>
             {children}

--- a/components/layout/mobile-sidebar.tsx
+++ b/components/layout/mobile-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { ComponentType } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -9,7 +10,14 @@ import { useAuth } from "@/contexts/auth-context"
 import { useRouter } from "next/navigation"
 import { LayoutDashboard, Target, BarChart3, Trophy, Gift, Users, MessageCircle, LogOut } from "lucide-react"
 
-const navigationItems = [
+type NavItem = {
+  name: string
+  href: string
+  icon: ComponentType<any>
+  badge: string | null
+}
+
+const defaultNavItems: NavItem[] = [
   {
     name: "Panel de Control",
     href: "/dashboard/control",
@@ -54,7 +62,7 @@ const navigationItems = [
   },
 ]
 
-export function MobileSidebar() {
+export function MobileSidebar({ navItems = defaultNavItems }: { navItems?: NavItem[] }) {
   const pathname = usePathname()
   const { logout } = useAuth()
   const router = useRouter()
@@ -68,7 +76,7 @@ export function MobileSidebar() {
     <div className="flex h-full flex-col">
       {/* Navigation - Más compacto */}
       <nav className="flex-1 p-2 space-y-1">
-        {navigationItems.map((item) => {
+        {navItems.map((item) => {
           const isActive = pathname === item.href || pathname.startsWith(item.href + "/")
           const Icon = item.icon
 


### PR DESCRIPTION
## Summary
- replace Google Inter font with local Geist Sans
- allow mobile sidebar to accept navigation items and use in Salud layout

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689284d1365c832ca0c1711605f15b59