### PR TITLE
Fix diagnostic service imports and module scoring

### DIFF
--- a/app/api/diagnostic/answers/route.ts
+++ b/app/api/diagnostic/answers/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { saveUserAnswer } from '@/lib/server/mysql';
+import { saveUserAnswer } from '@/lib/server/diagnostic-service';
 
 export async function POST(request: Request) {
   try {

--- a/app/api/diagnostic/modules/route.ts
+++ b/app/api/diagnostic/modules/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDiagnosticModules } from '@/lib/server/mysql';
+import { getDiagnosticModules } from '@/lib/server/diagnostic-service';
 
 export async function GET() {
   try {

--- a/app/api/diagnostic/progress/route.ts
+++ b/app/api/diagnostic/progress/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getDiagnosticProgress } from '@/lib/server/mysql';
+import { getUserProgress } from '@/lib/server/diagnostic-service';
 
 export async function GET(request: Request) {
   try {
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
       );
     }
 
-    const progress = await getDiagnosticProgress(userId, moduleId);
+    const progress = await getUserProgress(userId, moduleId);
     return NextResponse.json(progress);
   } catch (error) {
     console.error('Error fetching diagnostic progress:', error);

--- a/app/api/diagnostic/questions/route.ts
+++ b/app/api/diagnostic/questions/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { getModuleQuestions } from '@/lib/server/mysql';
+import { getModuleQuestions } from '@/lib/server/diagnostic-service';
 
 export async function GET(request: Request) {
   try {

--- a/app/api/diagnostic/results/route.ts
+++ b/app/api/diagnostic/results/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server';
-import { calculateModuleScore } from '@/lib/server/mysql';
+import { calculateModuleScore } from '@/lib/server/diagnostic-service';
 
 export async function GET(request: Request) {
   try {

--- a/lib/server/diagnostic-service.ts
+++ b/lib/server/diagnostic-service.ts
@@ -116,3 +116,57 @@ export async function getUserProgress(userId: string, moduleId: string) {
     throw error;
   }
 }
+
+export async function calculateModuleScore(userId: string, moduleId: string) {
+  try {
+    const [rows] = await pool.query(
+      `
+      SELECT
+        s.id as submodule_id,
+        s.title as submodule_title,
+        COALESCE(ua.calculated_score, 0) as user_score,
+        MAX(o.weight) as max_score
+      FROM diagnostic_questions q
+      JOIN diagnostic_submodules s ON q.submodule_id = s.id
+      LEFT JOIN diagnostic_options o ON o.question_id = q.id
+      LEFT JOIN user_diagnostic_answers ua ON ua.question_id = q.id AND ua.user_id = ?
+      WHERE s.module_id = ?
+      GROUP BY q.id, s.id, s.title, ua.calculated_score
+    `,
+      [userId, moduleId]
+    );
+
+    const breakdown: Record<string, { title: string; score: number; maxScore: number }> = {};
+    let totalScore = 0;
+    let maxPossibleScore = 0;
+
+    for (const row of rows as any[]) {
+      totalScore += row.user_score;
+      maxPossibleScore += row.max_score || 0;
+
+      if (!breakdown[row.submodule_id]) {
+        breakdown[row.submodule_id] = {
+          title: row.submodule_title,
+          score: 0,
+          maxScore: 0,
+        };
+      }
+      breakdown[row.submodule_id].score += row.user_score;
+      breakdown[row.submodule_id].maxScore += row.max_score || 0;
+    }
+
+    const percentageScore = maxPossibleScore
+      ? Number(((totalScore / maxPossibleScore) * 100).toFixed(2))
+      : 0;
+
+    return {
+      totalScore,
+      maxPossibleScore,
+      percentageScore,
+      breakdown,
+    };
+  } catch (error) {
+    console.error('Error calculating module score:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- route imports now use diagnostic-service
- add `calculateModuleScore` for module results
- expose progress via `getUserProgress`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689a5687f4b4832ca8ffbf8854ff6657